### PR TITLE
Make text to replace consistent

### DIFF
--- a/samples/EnvironmentalSensorInline.capabilitymodel.json
+++ b/samples/EnvironmentalSensorInline.capabilitymodel.json
@@ -1,5 +1,5 @@
 {
-  "@id": "urn:YOUR_COMPANY_NAME_HERE:sample_device:1",
+  "@id": "urn:<YOUR_COMPANY_NAME_HERE>:sample_device:1",
   "@type": "CapabilityModel",
   "displayName": "Environment Sensor Capability Model",
   "implements": [


### PR DESCRIPTION
The two instances of `YOUR_COMPANY_NAME_HERE` in the DCM were inconsistent.