### PR TITLE
Add Thermostat sample

### DIFF
--- a/DTDL/v2/samples/Diagnostics.json
+++ b/DTDL/v2/samples/Diagnostics.json
@@ -1,0 +1,26 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:com:example:Diagnostics;1",
+    "@type": "Interface",
+    "displayName": "Diagnostics",
+    "description": "Provides functionality to report memory usage and reboot the device.",
+    "contents": [
+      {
+        "@type": "Telemetry",
+        "description": "Current workingset of the device application",
+        "displayName": "Workingset",
+        "name": "workingset",
+        "schema": "long"
+      },
+      {
+        "@type": "Command",
+        "description": "This command will reboot the device application.",
+        "displayName": "Reboot",
+        "name": "reboot",
+        "request": {
+          "name": "delay",
+          "schema": "integer"
+        }
+      }
+    ]  
+}

--- a/DTDL/v2/samples/TemperatureSensor.json
+++ b/DTDL/v2/samples/TemperatureSensor.json
@@ -1,0 +1,37 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:example:TemperatureSensor;1",
+  "@type": "Interface",
+  "displayName": "Temperature Sensor",
+  "description": "Report temperature, and allows to control the target temperature remotely.",
+  "comment": "Requires temperature sensors.",
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": "Target Temperature",
+      "description": "Desired temperature to configure remotely.",
+      "name": "targetTemperature",
+      "schema": "double",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "displayName": "Current Temperature",
+      "description": "Current temperature reported from the device.",
+      "name": "currentTemperature",
+      "schema": "double",
+      "writable": false
+    },
+    {
+      "@type": [
+        "Telemetry",
+        "Temperature"
+      ],
+      "description": "Current temperature on the device.",
+      "displayName": "Temperature",
+      "name": "temperature",
+      "schema": "double",
+      "unit": "degreeCelsius"
+    }
+  ]
+}

--- a/DTDL/v2/samples/Thermostat.json
+++ b/DTDL/v2/samples/Thermostat.json
@@ -1,0 +1,28 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:com:example:Thermostat;1",
+  "@type": "Interface",
+  "displayName": "Thermostat with temperature sensor and diagnostics.",
+  "contents": [
+    {
+      "@type": "Component",
+      "schema": "dtmi:com:example:TemperatureSensor;1",
+      "name": "tempSensor1"
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:com:example:Diagnostics;1",
+      "name": "diag"
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
+      "name": "deviceInfo"
+    },
+    {
+      "@type": "Component",
+      "schema": "dtmi:azure:Client:SDKInformation;1",
+      "name": "sdkInfo"
+    }   
+  ]
+}


### PR DESCRIPTION
This PR adds 3 files to show a sample device using components from custom and common interfaces.

**Thermostat**
- TemperatureSensor
- Diagnostics
- [DeviceInfo](https://repo.azureiotrepository-test.com/Models/dtmi:azure:DeviceManagement:DeviceInformation;1?api-version=2020-05-01-preview)
- [SdkInfo](https://repo.azureiotrepository-test.com/Models/dtmi:azure:Client:SDKInformation;1?api-version=2020-05-01-preview)

> Note DeviceInfo and SdkInfo can be obtained from the public repo
