### PR TITLE
Suggestion implementation `wattHour` as unit of Energy

### DIFF
--- a/DTDL/v2/context/DTDL.v2.context.json
+++ b/DTDL/v2/context/DTDL.v2.context.json
@@ -394,6 +394,7 @@
   "gigajoule": { "@id": "dtmi:standard:unit:gigajoule;2" },
   "electronvolt": { "@id": "dtmi:standard:unit:electronvolt;2" },
   "megaelectronvolt": { "@id": "dtmi:standard:unit:megaelectronvolt;2" },
+  "wattHour": { "@id": "dtmi:standard:unit:wattHour;2" },
   "kilowattHour": { "@id": "dtmi:standard:unit:kilowattHour;2" },
   "newton": { "@id": "dtmi:standard:unit:newton;2" },
   "pound": { "@id": "dtmi:standard:unit:pound;2" },

--- a/DTDL/v2/dtdlv2.md
+++ b/DTDL/v2/dtdlv2.md
@@ -760,7 +760,7 @@ The chart below lists standard semantic types, corresponding unit types, and ava
 | `Density` | `DensityUnit` | `kilogramPerCubicMetre` <br> `gramPerCubicMetre` |
 | `Distance` | `LengthUnit` | `metre` <br> `centimetre` <br> `millimetre` <br> `micrometre` <br> `nanometre` <br> `kilometre` <br> `foot` <br> `inch` <br> `mile` <br> `nauticalMile` <br> `astronomicalUnit` |
 | `ElectricCharge` | `ChargeUnit` | `coulomb` |
-| `Energy` | `EnergyUnit` | `joule` <br> `kilojoule` <br> `megajoule` <br> `gigajoule` <br> `electronvolt` <br> `megaelectronvolt` <br> `kilowattHour` |
+| `Energy` | `EnergyUnit` | `joule` <br> `kilojoule` <br> `megajoule` <br> `gigajoule` <br> `electronvolt` <br> `megaelectronvolt` <br> `wattHour` <br> `kilowattHour` |
 | `Force` | `ForceUnit` | `newton` <br> `pound` <br> `ounce` <br> `ton` |
 | `Frequency` | `FrequencyUnit` | `hertz` <br> `kilohertz` <br> `megahertz` <br> `gigahertz` |
 | `Humidity` | `DensityUnit` | `kilogramPerCubicMetre` <br> `gramPerCubicMetre` |


### PR DESCRIPTION
Hi, 

I'm wondering why `wattHour` is not a suggested unit of Energy that can be used in DTDL?  Would this be a useful addition? I'm working on a product that is build on top of DTDL.

Kind regards,

Gilles